### PR TITLE
Adicionando backend S3 para o terraform

### DIFF
--- a/.github/workflows/1-validate.yaml
+++ b/.github/workflows/1-validate.yaml
@@ -22,6 +22,9 @@ jobs:
 
     - name: Terraform Init
       run: terraform init
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
     - name: Terraform Validate
       run: terraform validate

--- a/.github/workflows/2-deploy.yaml
+++ b/.github/workflows/2-deploy.yaml
@@ -21,6 +21,9 @@ jobs:
 
     - name: Terraform Init
       run: terraform init
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
     - name: Terraform Plan
       run: terraform plan -out=tfplan -var="db_username=${{ secrets.DB_USERNAME }}" -var="db_password=${{ secrets.DB_PASSWORD }}"

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,13 @@
 provider "aws" {
-  region  = "us-east-2"
+  region  = "us-east-1"
+}
+
+terraform {
+  backend "s3" {
+    bucket = "state-terraform-fiap-grupo-52"
+    key    = "infra-sgbd"
+    region = "us-east-1"
+  }
 }
 
 resource "aws_default_vpc" "default_vpc" {}


### PR DESCRIPTION
Para permitir a execução dos planos, o estado precisa ser salvo. Esse PR adiciona S3 como backend para salvar o estado do terraform.